### PR TITLE
Fix for ClassCastException

### DIFF
--- a/src/main/java/com/github/paweladamski/httpclientmock/condition/BodyMatcher.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/condition/BodyMatcher.java
@@ -3,7 +3,8 @@ package com.github.paweladamski.httpclientmock.condition;
 import com.github.paweladamski.httpclientmock.Debugger;
 import com.github.paweladamski.httpclientmock.Request;
 import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpRequest;
 import org.apache.http.util.EntityUtils;
 import org.hamcrest.Matcher;
 
@@ -20,12 +21,18 @@ public class BodyMatcher implements Condition {
     @Override
     public boolean matches(Request request) {
         try {
-            HttpEntity entity = ((HttpEntityEnclosingRequestBase) request.getHttpRequest()).getEntity();
-            if (entity == null) {
+            HttpRequest httpRequest = request.getHttpRequest();
+            if (httpRequest instanceof HttpEntityEnclosingRequest) {
+                HttpEntity entity = ((HttpEntityEnclosingRequest) httpRequest).getEntity();
+                if (entity == null) {
+                    return false;
+                }
+                String message = EntityUtils.toString(entity);
+
+                return matcher.matches(message);
+            } else {
                 return false;
             }
-            String message = EntityUtils.toString(entity);
-            return matcher.matches(message);
         } catch (IOException e) {
             return false;
         }

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientResponseBuilderTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientResponseBuilderTest.java
@@ -7,6 +7,7 @@ import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.message.BasicHttpResponse;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -17,6 +18,7 @@ import static com.github.paweladamski.httpclientmock.Requests.httpGet;
 import static com.github.paweladamski.httpclientmock.Requests.httpPost;
 import static com.github.paweladamski.httpclientmock.matchers.HttpResponseMatchers.hasContent;
 import static com.github.paweladamski.httpclientmock.matchers.HttpResponseMatchers.hasStatus;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.apache.http.entity.ContentType.APPLICATION_XML;
@@ -205,6 +207,17 @@ public class HttpClientResponseBuilderTest {
         HttpResponse login = httpClientMock.execute(httpGet("http://localhost:8080/login"));
 
         assertNull(login.getEntity());
+    }
+
+    @Test
+    public void should_not_throw_exception_when_body_matcher_is_present_on_post_request() throws IOException {
+        HttpClientMock httpClientMock = new HttpClientMock("http://localhost:8080");
+        httpClientMock.onPost("/path1")
+                      .withBody(equalTo("Body content"))
+                      .doReturnStatus(200);
+
+        HttpResponse response = httpClientMock.execute(httpGet("http://localhost:8080/path2"));
+        Assert.assertThat(response, hasStatus(SC_NOT_FOUND));
     }
 
     private Action echo() {


### PR DESCRIPTION
Fix for ClassCastException when executing request which should normally return 404 status code.

Exception was raised in BodyMatcher when it was present in client configuration and request path was not configured. So now test just fails silently instead of falling with unexpected error. 