### PR TITLE
 Add support for URL-encoded form parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ httpClient.execute(new HttpPost("http://localhost/login")); // returns response 
 #### Verify
 When code under test finishes, HttpClientMock allows to check number of made request. It is possible to use the same set of conditions as for defining mock behaviour.
 ```
-httpClientMock.verify().get("http://localhost/login").withParameter("user","john").called()
-httpClientMock.verify().post("http://localhost/login").notCalled()
+httpClientMock.verify().get("http://localhost/login").withParameter("user","john").called();
+httpClientMock.verify().post("http://localhost/login").notCalled();
 ```
 
 
@@ -53,7 +53,7 @@ httpClientMock.onGet().doReturn("get");
 httpClientMock.onPost().doReturn("post");
 httpClientMock.onPut().doReturn("put");
 httpClientMock.onDelete().doReturn("delete");
-httpClientMock.onOptions().doReturn("options");
+httpClientMock.onOption().doReturn("options");
 httpClientMock.onHead().doReturn("head");
 ```
 ### URL
@@ -100,7 +100,7 @@ httpClientMock.onGet("http://localhost/login")
 ### Body condition
 ```
 httpClientMock.onGet("http://localhost/login")
-  .withBody("tracking",containsString(123))
+  .withBody("tracking",containsString("123"))
   .doReturn("ok");
 ```
 
@@ -132,13 +132,13 @@ If request doesn't matche any rule, HttpClientMock return response with status 4
 ### Response
 Response with provided body and status 200.
 ```
-httpClientMock.onGet("http://localhost").doReturn("my response")
+httpClientMock.onGet("http://localhost").doReturn("my response");
 ```
 ### Status
 Response with empty body and provided status
 ```
-httpClientMock.onGet("http://localhost").doReturnStatus(300)
-httpClientMock.onGet("http://localhost").doReturn("Overloaded").withStatus("500");
+httpClientMock.onGet("http://localhost").doReturnStatus(300);
+httpClientMock.onGet("http://localhost").doReturn("Overloaded").withStatus(500);
 ```
 ### Exception
 Instead of returning response it throws defined exception.
@@ -147,7 +147,7 @@ httpClientMock.onGet("http://localhost").doThrowException(new IOException());
 ```
 ### Custom action
 ```
-Action echo r -> {
+Action echo = r -> {
   HttpEntity entity = ((HttpEntityEnclosingRequestBase) r.getHttpRequest()).getEntity();
   BasicHttpResponse response = new BasicHttpResponse(new ProtocolVersion("http", 1, 1), 200, "ok");
   response.setEntity(entity);
@@ -157,11 +157,11 @@ httpClientMock.onGet("http://localhost").doAction(echo);
 ```
 ### Response header
 ```
-httpClientMock.onPost("/login").doReturn("foo").withHeader("tracking", "123")
+httpClientMock.onPost("/login").doReturn("foo").withHeader("tracking", "123");
 ```
 ### Response status
 ```
-httpClientMock.onPost("/login?user=bar").doReturn("Wrong user").withStatus(403)
+httpClientMock.onPost("/login?user=bar").doReturn("Wrong user").withStatus(403);
 ```
 
 ### JSON
@@ -180,7 +180,7 @@ httpClientMock.onPost("/login").doReturnXML("<foo>bar</foo>");
 It is possible to add multiple actions to one rule. Every call will use next action until last is reached.
 ```
 httpClientMock.onPut("/addUser")
-  .doReturn("ok");
+  .doReturn("ok")
   .doReturnStatus(500);
 
 httpClientMock.execute(new HttpPut("http://localhost/addUser")); //returns "ok"

--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilder.java
@@ -8,6 +8,10 @@ import com.github.paweladamski.httpclientmock.condition.Condition;
 import com.github.paweladamski.httpclientmock.condition.HeaderCondition;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+import org.apache.http.NameValuePair;
 import org.apache.http.entity.ContentType;
 import org.hamcrest.Matcher;
 
@@ -89,6 +93,29 @@ public class HttpClientMockBuilder {
   }
 
   /**
+   * Request body must contain the given URL-encoded form parameter (typically found in POST requests). Alternatively, parameters may be specified all at once using {@link #withBody(Map)}.
+   *
+   * @param name parameter name
+   * @param value expected parameter value
+   * @return condition builder
+   */
+  public HttpClientMockBuilder withFormParameter(String name, String value) {
+    return withFormParameter(name, equalTo(value));
+  }
+
+  /**
+   * Request body must contain the given URL-encoded form parameter (typically found in POST requests). Alternatively, parameters may be specified all at once using {@link #withBody(Map)}.
+   *
+   * @param name parameter name
+   * @param matcher parameter value matcher
+   * @return condition builder
+   */
+  public HttpClientMockBuilder withFormParameter(String name, Matcher<String> matcher) {
+    ruleBuilder.addFormParameterCondition(name, matcher);
+    return this;
+  }
+
+  /**
    * Adds custom conditions.
    *
    * @param condition custom condition
@@ -107,6 +134,17 @@ public class HttpClientMockBuilder {
    */
   public HttpClientMockBuilder withBody(Matcher<String> matcher) {
     ruleBuilder.addCondition(new BodyMatcher(matcher));
+    return this;
+  }
+
+  /**
+   * Adds body condition. Request body must contain the given URL-encoded form parameters (typically used in POST requests). Alternatively, parameters may be specified individually using {@link #withFormParameter(String, Matcher)}.
+   * 
+   * @param parameters the parameters
+   * @return condition builder
+   */
+  public HttpClientMockBuilder withBody(Map<String, Matcher<String>> parameters) {
+    ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }
 
@@ -266,4 +304,23 @@ public class HttpClientMockBuilder {
     return responseBuilder.doReturnXML(response, charset);
   }
 
+  /**
+   * Adds action which returns provided URL-encoded parameter response in UTF-8 and status 200. Additionally it sets "Content-type" header to "application/x-www-form-urlencoded".
+   *
+   * @param bodyParameters parameters to return
+   * @return response builder
+   */
+  public HttpClientResponseBuilder doReturnFormParams(Collection<NameValuePair> parameters) {
+    return doReturnFormParams(parameters, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Adds action which returns provided URL-encoded parameter response with status 200. Additionally it sets "Content-type" header to "application/x-www-form-urlencoded".
+   *
+   * @param bodyParameters parameters to return
+   * @return response builder
+   */
+  public HttpClientResponseBuilder doReturnFormParams(Collection<NameValuePair> parameters, Charset charset) {
+    return responseBuilder.doReturnFormParams(parameters, charset);
+  }
 }

--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilder.java
@@ -6,6 +6,7 @@ import com.github.paweladamski.httpclientmock.action.Action;
 import com.github.paweladamski.httpclientmock.condition.BodyMatcher;
 import com.github.paweladamski.httpclientmock.condition.Condition;
 import com.github.paweladamski.httpclientmock.condition.HeaderCondition;
+import com.github.paweladamski.httpclientmock.matchers.MatchersMap;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -143,7 +144,7 @@ public class HttpClientMockBuilder {
    * @param parameters the parameters
    * @return condition builder
    */
-  public HttpClientMockBuilder withBody(Map<String, Matcher<String>> parameters) {
+  public HttpClientMockBuilder withBody(MatchersMap<String, String> parameters) {
     ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }

--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilder.java
@@ -94,7 +94,9 @@ public class HttpClientMockBuilder {
   }
 
   /**
-   * Request body must contain the given URL-encoded form parameter (typically found in POST requests). Alternatively, parameters may be specified all at once using {@link #withBody(Map)}.
+   * Request body must contain the given URL-encoded form parameter (typically
+   * found in POST requests). Alternatively, parameters may be specified all at
+   * once using {@link #withFormParameters(MatchersMap)}.
    *
    * @param name parameter name
    * @param value expected parameter value
@@ -105,7 +107,9 @@ public class HttpClientMockBuilder {
   }
 
   /**
-   * Request body must contain the given URL-encoded form parameter (typically found in POST requests). Alternatively, parameters may be specified all at once using {@link #withBody(Map)}.
+   * Request body must contain the given URL-encoded form parameter (typically
+   * found in POST requests). Alternatively, parameters may be specified all at
+   * once using {@link #withFormParameters(MatchersMap)}.
    *
    * @param name parameter name
    * @param matcher parameter value matcher
@@ -113,6 +117,19 @@ public class HttpClientMockBuilder {
    */
   public HttpClientMockBuilder withFormParameter(String name, Matcher<String> matcher) {
     ruleBuilder.addFormParameterCondition(name, matcher);
+    return this;
+  }
+  
+  /**
+   * Request body must contain the given URL-encoded form parameters (typically
+   * used in POST requests). Alternatively, parameters may be specified
+   * individually using {@link #withFormParameter(String, Matcher)}.
+   * 
+   * @param parameters the parameters
+   * @return condition builder
+   */
+  public HttpClientMockBuilder withFormParameters(MatchersMap<String, String> parameters) {
+    ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }
 
@@ -135,17 +152,6 @@ public class HttpClientMockBuilder {
    */
   public HttpClientMockBuilder withBody(Matcher<String> matcher) {
     ruleBuilder.addCondition(new BodyMatcher(matcher));
-    return this;
-  }
-
-  /**
-   * Adds body condition. Request body must contain the given URL-encoded form parameters (typically used in POST requests). Alternatively, parameters may be specified individually using {@link #withFormParameter(String, Matcher)}.
-   * 
-   * @param parameters the parameters
-   * @return condition builder
-   */
-  public HttpClientMockBuilder withBody(MatchersMap<String, String> parameters) {
-    ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }
 

--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientResponseBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientResponseBuilder.java
@@ -9,10 +9,13 @@ import com.github.paweladamski.httpclientmock.action.ExceptionAction;
 import com.github.paweladamski.httpclientmock.action.HeaderAction;
 import com.github.paweladamski.httpclientmock.action.StatusResponse;
 import com.github.paweladamski.httpclientmock.action.StringResponse;
+import com.github.paweladamski.httpclientmock.action.UrlEncodedFormEntityResponse;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import org.apache.http.entity.ContentType;
+import org.apache.http.NameValuePair;
 
 public class HttpClientResponseBuilder {
 
@@ -190,6 +193,27 @@ public class HttpClientResponseBuilder {
    */
   public HttpClientResponseBuilder doReturnXML(String response, Charset charset) {
     return doReturn(response, charset, APPLICATION_XML);
+  }
+  
+  /**
+   * Adds action which returns provided name/value pairs as URL-encoded form response in UTF-8 and status 200. Additionally it sets "Content-type" header to "application/x-www-form-urlencoded".
+   *
+   * @param formParameters the parameters to include in the response
+   * @return response builder
+   */
+  public HttpClientResponseBuilder doReturnFormParams(Collection<NameValuePair> formParameters) {
+    return doReturnFormParams(formParameters, StandardCharsets.UTF_8);
+  }
+  
+  /**
+   * Adds action which returns provided name/value pairs as URL-encoded form response and status 200. Additionally it sets "Content-type" header to "application/x-www-form-urlencoded".
+   *
+   * @param formParameters the parameters to include in the response
+   * @return response builder
+   */
+  public HttpClientResponseBuilder doReturnFormParams(Collection<NameValuePair> formParameters, Charset charset) {
+    newRule.addAction(new UrlEncodedFormEntityResponse(formParameters, charset));
+    return new HttpClientResponseBuilder(newRule);
   }
 
 }

--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientVerifyBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientVerifyBuilder.java
@@ -6,6 +6,7 @@ import com.github.paweladamski.httpclientmock.condition.BodyMatcher;
 import com.github.paweladamski.httpclientmock.condition.Condition;
 import com.github.paweladamski.httpclientmock.condition.HeaderCondition;
 import java.util.List;
+import java.util.Map;
 import org.hamcrest.Matcher;
 
 public class HttpClientVerifyBuilder {
@@ -84,6 +85,33 @@ public class HttpClientVerifyBuilder {
     ruleBuilder.addParameterCondition(name, matcher);
     return this;
   }
+  
+  /**
+   * Request body must contain the given URL-encoded form parameter (typically
+   * found in POST requests). Alternatively, parameters may be specified all at
+   * once using {@link #withBody(Map)}.
+   *
+   * @param name parameter name
+   * @param value expected parameter value
+   * @return condition builder
+   */
+  public HttpClientVerifyBuilder withFormParameter(String name, String value) {
+    return withFormParameter(name, equalTo(value));
+  }
+
+  /**
+   * Request body must contain the given URL-encoded form parameter (typically
+   * found in POST requests). Alternatively, parameters may be specified all at
+   * once using {@link #withBody(Map)}.
+   *
+   * @param name parameter name
+   * @param matcher parameter value matcher
+   * @return condition builder
+   */
+  public HttpClientVerifyBuilder withFormParameter(String name, Matcher<String> matcher) {
+    ruleBuilder.addFormParameterCondition(name, matcher);
+    return this;
+  }
 
   /**
    * Adds custom conditions.
@@ -104,6 +132,20 @@ public class HttpClientVerifyBuilder {
    */
   public HttpClientVerifyBuilder withBody(Matcher<String> matcher) {
     ruleBuilder.addCondition(new BodyMatcher(matcher));
+    return this;
+  }
+  
+  /**
+   * Adds body condition. Request body must contain the given URL-encoded form
+   * parameters (typically used in POST requests). Alternatively, parameters may
+   * be specified individually using
+   * {@link #withFormParameter(String, Matcher)}.
+   * 
+   * @param parameters the parameters
+   * @return condition builder
+   */
+  public HttpClientVerifyBuilder withBody(Map<String, Matcher<String>> parameters) {
+    ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }
 

--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientVerifyBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientVerifyBuilder.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import com.github.paweladamski.httpclientmock.condition.BodyMatcher;
 import com.github.paweladamski.httpclientmock.condition.Condition;
 import com.github.paweladamski.httpclientmock.condition.HeaderCondition;
+import com.github.paweladamski.httpclientmock.matchers.MatchersMap;
 import java.util.List;
 import java.util.Map;
 import org.hamcrest.Matcher;
@@ -144,7 +145,7 @@ public class HttpClientVerifyBuilder {
    * @param parameters the parameters
    * @return condition builder
    */
-  public HttpClientVerifyBuilder withBody(Map<String, Matcher<String>> parameters) {
+  public HttpClientVerifyBuilder withBody(MatchersMap<String, String> parameters) {
     ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }

--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientVerifyBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientVerifyBuilder.java
@@ -90,7 +90,7 @@ public class HttpClientVerifyBuilder {
   /**
    * Request body must contain the given URL-encoded form parameter (typically
    * found in POST requests). Alternatively, parameters may be specified all at
-   * once using {@link #withBody(Map)}.
+   * once using {@link #withFormParameters(MatchersMap)}.
    *
    * @param name parameter name
    * @param value expected parameter value
@@ -103,7 +103,7 @@ public class HttpClientVerifyBuilder {
   /**
    * Request body must contain the given URL-encoded form parameter (typically
    * found in POST requests). Alternatively, parameters may be specified all at
-   * once using {@link #withBody(Map)}.
+   * once using {@link #withFormParameters(MatchersMap)}.
    *
    * @param name parameter name
    * @param matcher parameter value matcher
@@ -111,6 +111,19 @@ public class HttpClientVerifyBuilder {
    */
   public HttpClientVerifyBuilder withFormParameter(String name, Matcher<String> matcher) {
     ruleBuilder.addFormParameterCondition(name, matcher);
+    return this;
+  }
+  
+  /**
+   * Request body must contain the given URL-encoded form parameters (typically
+   * used in POST requests). Alternatively, parameters may be specified
+   * individually using {@link #withFormParameter(String, Matcher)}.
+   * 
+   * @param parameters the parameters
+   * @return condition builder
+   */
+  public HttpClientVerifyBuilder withFormParameters(MatchersMap<String, String> parameters) {
+    ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }
 
@@ -133,20 +146,6 @@ public class HttpClientVerifyBuilder {
    */
   public HttpClientVerifyBuilder withBody(Matcher<String> matcher) {
     ruleBuilder.addCondition(new BodyMatcher(matcher));
-    return this;
-  }
-  
-  /**
-   * Adds body condition. Request body must contain the given URL-encoded form
-   * parameters (typically used in POST requests). Alternatively, parameters may
-   * be specified individually using
-   * {@link #withFormParameter(String, Matcher)}.
-   * 
-   * @param parameters the parameters
-   * @return condition builder
-   */
-  public HttpClientVerifyBuilder withBody(MatchersMap<String, String> parameters) {
-    ruleBuilder.addFormParameterConditions(parameters);
     return this;
   }
 

--- a/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
@@ -13,20 +13,22 @@ class RuleBuilder {
 
   private final List<Action> actions = new ArrayList<>();
   private final List<Condition> conditions = new ArrayList<>();
-  private UrlEncodedFormCondition formParametersCondition;
+  private final UrlEncodedFormCondition formParametersCondition = new UrlEncodedFormCondition();
   private final UrlConditions urlConditions = new UrlConditions();
 
   RuleBuilder(String method, String defaultHost, String url) {
+    this(method);
+    
     UrlParser urlParser = new UrlParser();
     if (url.startsWith("/")) {
       url = defaultHost + url;
     }
-    addCondition(new HttpMethodCondition(method));
     addUrlConditions(urlParser.parse(url));
   }
 
   RuleBuilder(String method) {
     addCondition(new HttpMethodCondition(method));
+    addCondition(formParametersCondition);
   }
 
   void addAction(Action o) {
@@ -48,18 +50,10 @@ class RuleBuilder {
   }
   
   void addFormParameterCondition(String name, Matcher<String> matcher) {
-	  if (formParametersCondition == null) {
-		  formParametersCondition = new UrlEncodedFormCondition();
-		  addCondition(formParametersCondition);
-	  }
-	  formParametersCondition.addExpectedParameter(name, matcher);
+	formParametersCondition.addExpectedParameter(name, matcher);
   }
   
   void addFormParameterConditions(Map<String, Matcher<String>> parameters) {
-    if (formParametersCondition == null) {
-    	formParametersCondition = new UrlEncodedFormCondition();
-      addCondition(formParametersCondition);
-    }
     formParametersCondition.addExpectedParameters(parameters);
   }
 

--- a/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
@@ -3,14 +3,17 @@ package com.github.paweladamski.httpclientmock;
 import com.github.paweladamski.httpclientmock.action.Action;
 import com.github.paweladamski.httpclientmock.condition.Condition;
 import com.github.paweladamski.httpclientmock.condition.HttpMethodCondition;
+import com.github.paweladamski.httpclientmock.condition.UrlEncodedFormCondition;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.hamcrest.Matcher;
 
 class RuleBuilder {
 
   private final List<Action> actions = new ArrayList<>();
   private final List<Condition> conditions = new ArrayList<>();
+  private UrlEncodedFormCondition formParametersCondition;
   private final UrlConditions urlConditions = new UrlConditions();
 
   RuleBuilder(String method, String defaultHost, String url) {
@@ -42,6 +45,22 @@ class RuleBuilder {
     UrlConditions urlConditions = new UrlConditions();
     urlConditions.getParameterConditions().put(name, matcher);
     addUrlConditions(urlConditions);
+  }
+  
+  void addFormParameterCondition(String name, Matcher<String> matcher) {
+	  if (formParametersCondition == null) {
+		  formParametersCondition = new UrlEncodedFormCondition();
+		  addCondition(formParametersCondition);
+	  }
+	  formParametersCondition.addExpectedParameter(name, matcher);
+  }
+  
+  void addFormParameterConditions(Map<String, Matcher<String>> parameters) {
+    if (formParametersCondition == null) {
+    	formParametersCondition = new UrlEncodedFormCondition();
+      addCondition(formParametersCondition);
+    }
+    formParametersCondition.addExpectedParameters(parameters);
   }
 
   void addReferenceCondition(Matcher<String> matcher) {

--- a/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
@@ -50,7 +50,7 @@ class RuleBuilder {
   }
   
   void addFormParameterCondition(String name, Matcher<String> matcher) {
-	formParametersCondition.addExpectedParameter(name, matcher);
+    formParametersCondition.addExpectedParameter(name, matcher);
   }
   
   void addFormParameterConditions(MatchersMap<String, String> parameters) {

--- a/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/RuleBuilder.java
@@ -4,9 +4,9 @@ import com.github.paweladamski.httpclientmock.action.Action;
 import com.github.paweladamski.httpclientmock.condition.Condition;
 import com.github.paweladamski.httpclientmock.condition.HttpMethodCondition;
 import com.github.paweladamski.httpclientmock.condition.UrlEncodedFormCondition;
+import com.github.paweladamski.httpclientmock.matchers.MatchersMap;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.hamcrest.Matcher;
 
 class RuleBuilder {
@@ -53,7 +53,7 @@ class RuleBuilder {
 	formParametersCondition.addExpectedParameter(name, matcher);
   }
   
-  void addFormParameterConditions(Map<String, Matcher<String>> parameters) {
+  void addFormParameterConditions(MatchersMap<String, String> parameters) {
     formParametersCondition.addExpectedParameters(parameters);
   }
 

--- a/src/main/java/com/github/paweladamski/httpclientmock/action/UrlEncodedFormEntityResponse.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/action/UrlEncodedFormEntityResponse.java
@@ -1,0 +1,42 @@
+package com.github.paweladamski.httpclientmock.action;
+
+import java.nio.charset.Charset;
+import java.util.Collection;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.message.BasicHttpResponse;
+
+import com.github.paweladamski.httpclientmock.Request;
+
+/**
+ * @author Michael Angstadt
+ */
+public class UrlEncodedFormEntityResponse implements Action {
+
+  private final int statusCode;
+  private final Collection<NameValuePair> pairs;
+  private final Charset charset;
+
+  public UrlEncodedFormEntityResponse(Collection<NameValuePair> pairs, Charset charset) {
+    this(200, pairs, charset);
+  }
+
+  public UrlEncodedFormEntityResponse(int statusCode, Collection<NameValuePair> pairs, Charset charset) {
+    this.statusCode = statusCode;
+    this.pairs = pairs;
+    this.charset = charset;
+  }
+
+  @Override
+  public HttpResponse getResponse(Request request) {
+    BasicHttpResponse response = new BasicHttpResponse(new ProtocolVersion("http", 1, 1), statusCode, "ok");
+
+    UrlEncodedFormEntity entity = new UrlEncodedFormEntity(pairs, charset);
+    response.setEntity(entity);
+
+    return response;
+  }
+}

--- a/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormCondition.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormCondition.java
@@ -18,9 +18,14 @@ import com.github.paweladamski.httpclientmock.Request;
  */
 public class UrlEncodedFormCondition implements Condition {
   private final Map<String, Matcher<String>> expected = new HashMap<>();
+  private boolean enabled = false;
 
   @Override
   public boolean matches(Request r) {
+    if (!enabled) {
+      return true;
+    }
+
     boolean requestHasBody = (r.getHttpRequest() instanceof HttpEntityEnclosingRequest);
     if (!requestHasBody) {
       //body-less requests only match if no parameters are expected
@@ -65,6 +70,7 @@ public class UrlEncodedFormCondition implements Condition {
    */
   public void addExpectedParameter(String name, Matcher<String> matcher) {
     expected.put(name, matcher);
+    enabled = true;
   }
 
   /**
@@ -73,5 +79,6 @@ public class UrlEncodedFormCondition implements Condition {
    */
   public void addExpectedParameters(Map<String, Matcher<String>> parameters) {
     expected.putAll(parameters);
+    enabled = true;
   }
 }

--- a/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormCondition.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormCondition.java
@@ -1,9 +1,7 @@
 package com.github.paweladamski.httpclientmock.condition;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -13,13 +11,14 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.hamcrest.Matcher;
 
 import com.github.paweladamski.httpclientmock.Request;
+import com.github.paweladamski.httpclientmock.matchers.MatchersMap;
 
 /**
  * Tests the request body for URL-encoded parameters.
  * @author Michael Angstadt
  */
 public class UrlEncodedFormCondition implements Condition {
-  private final Map<String, Matcher<String>> expected = new HashMap<>();
+  private final MatchersMap<String, String> expected = new MatchersMap<>();
   private boolean enabled = false;
 
   @Override
@@ -52,16 +51,7 @@ public class UrlEncodedFormCondition implements Condition {
   }
   
   private boolean allParamsHaveMatchingValue(List<NameValuePair> actual) {
-    for (NameValuePair actualPair : actual) {
-      String actualName = actualPair.getName();
-      String actualValue = actualPair.getValue();
-      
-      if (!expected.get(actualName).matches(actualValue)) {
-        return false;
-      }
-    }
-    
-    return true;
+    return actual.stream().allMatch(actualPair -> expected.matches(actualPair.getName(), actualPair.getValue()));
   }
   
   private List<NameValuePair> parseFormParameters(Request r) {
@@ -87,7 +77,7 @@ public class UrlEncodedFormCondition implements Condition {
    * Adds expected form parameters.
    * @param parameters the expected parameters
    */
-  public void addExpectedParameters(Map<String, Matcher<String>> parameters) {
+  public void addExpectedParameters(MatchersMap<String, String> parameters) {
     expected.putAll(parameters);
     enabled = true;
   }

--- a/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormCondition.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormCondition.java
@@ -1,0 +1,77 @@
+package com.github.paweladamski.httpclientmock.condition;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.hamcrest.Matcher;
+
+import com.github.paweladamski.httpclientmock.Request;
+
+/**
+ * Tests the request body for URL-encoded parameters.
+ * @author Michael Angstadt
+ */
+public class UrlEncodedFormCondition implements Condition {
+  private final Map<String, Matcher<String>> expected = new HashMap<>();
+
+  @Override
+  public boolean matches(Request r) {
+    boolean requestHasBody = (r.getHttpRequest() instanceof HttpEntityEnclosingRequest);
+    if (!requestHasBody) {
+      //body-less requests only match if no parameters are expected
+      return expected.isEmpty();
+    }
+
+    HttpEntityEnclosingRequest request = (HttpEntityEnclosingRequest) r.getHttpRequest();
+
+    List<NameValuePair> actual;
+    try {
+      actual = URLEncodedUtils.parse(request.getEntity());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    if (expected.size() != actual.size()) {
+      return false;
+    }
+
+    Map<String, Matcher<String>> expectedCopy = new HashMap<>(expected);
+    for (NameValuePair actualPair : actual) {
+      String actualName = actualPair.getName();
+
+      Matcher<String> expectedValue = expectedCopy.remove(actualName);
+      if (expectedValue == null) {
+        return false;
+      }
+
+      String actualValue = actualPair.getValue();
+      if (!expectedValue.matches(actualValue)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Adds an expected form parameter.
+   * @param name the parameter name
+   * @param matcher the expected value
+   */
+  public void addExpectedParameter(String name, Matcher<String> matcher) {
+    expected.put(name, matcher);
+  }
+
+  /**
+   * Adds expected form parameters.
+   * @param parameters the expected parameters
+   */
+  public void addExpectedParameters(Map<String, Matcher<String>> parameters) {
+    expected.putAll(parameters);
+  }
+}

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
@@ -336,32 +336,6 @@ public class HttpClientMockBuilderTest {
     )));
     HttpResponse response = httpClientMock.execute(request);
     assertThat(response, hasStatus(200));
-    
-    //username does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "Bob"),
-      new BasicNameValuePair("password", "secret!")
-    )));
-    response = httpClientMock.execute(request);
-    assertThat(response, hasStatus(404));
-    
-    //password does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "John"),
-      new BasicNameValuePair("password", "1234")
-    )));
-    response = httpClientMock.execute(request);
-    assertThat(response, hasStatus(404));
-    
-    //parameter name does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("phone", "123456789")
-    )));
-    response = httpClientMock.execute(request);
-    assertThat(response, hasStatus(404));
   }
   
   @Test
@@ -383,32 +357,6 @@ public class HttpClientMockBuilderTest {
     )));
     HttpResponse response = httpClientMock.execute(request);
     assertThat(response, hasStatus(200));
-    
-    //username does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "Bob"),
-      new BasicNameValuePair("password", "secret!")
-    )));
-    response = httpClientMock.execute(request);
-    assertThat(response, hasStatus(404));
-    
-    //password does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "John"),
-      new BasicNameValuePair("password", "1234")
-    )));
-    response = httpClientMock.execute(request);
-    assertThat(response, hasStatus(404));
-    
-    //parameter name does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("phone", "123456789")
-    )));
-    response = httpClientMock.execute(request);
-    assertThat(response, hasStatus(404));
   }
 
 }

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
@@ -336,6 +336,14 @@ public class HttpClientMockBuilderTest {
     )));
     HttpResponse response = httpClientMock.execute(request);
     assertThat(response, hasStatus(200));
+    
+    request = new HttpPost("http://localhost/login");
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("username", "John"),
+      new BasicNameValuePair("password", "wrong")
+    )));
+    response = httpClientMock.execute(request);
+    assertThat(response, hasStatus(404));
   }
   
   @Test
@@ -357,6 +365,14 @@ public class HttpClientMockBuilderTest {
     )));
     HttpResponse response = httpClientMock.execute(request);
     assertThat(response, hasStatus(200));
+    
+    request = new HttpPost("http://localhost/login");
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("username", "John"),
+      new BasicNameValuePair("password", "wrong")
+    )));
+    response = httpClientMock.execute(request);
+    assertThat(response, hasStatus(404));
   }
 
 }

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
@@ -347,7 +347,7 @@ public class HttpClientMockBuilderTest {
   }
   
   @Test
-  public void withBody_form_parameters() throws IOException {
+  public void withFormParameters() throws IOException {
     HttpClientMock httpClientMock = new HttpClientMock("http://localhost");
     
     MatchersMap<String, String> parameters = new MatchersMap<>();
@@ -355,7 +355,7 @@ public class HttpClientMockBuilderTest {
     parameters.put("password", Matchers.containsString("secret"));
     
     httpClientMock.onPost("/login")
-      .withBody(parameters)
+      .withFormParameters(parameters)
     .doReturnStatus(200);
     
     HttpPost request = new HttpPost("http://localhost/login");

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
@@ -7,10 +7,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
 import com.github.paweladamski.httpclientmock.condition.Condition;
+import com.github.paweladamski.httpclientmock.matchers.MatchersMap;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpDelete;
@@ -21,7 +20,6 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.message.BasicNameValuePair;
-import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -370,7 +368,7 @@ public class HttpClientMockBuilderTest {
   public void withBody_form_parameters() throws IOException {
     HttpClientMock httpClientMock = new HttpClientMock("http://localhost");
     
-    Map<String, Matcher<String>> parameters = new HashMap<>();
+    MatchersMap<String, String> parameters = new MatchersMap<>();
     parameters.put("username", Matchers.equalTo("John"));
     parameters.put("password", Matchers.containsString("secret"));
     

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientResponseBuilderTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientResponseBuilderTest.java
@@ -18,14 +18,19 @@ import com.github.paweladamski.httpclientmock.action.Action;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicNameValuePair;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -279,6 +284,34 @@ public class HttpClientResponseBuilderTest {
 
     HttpResponse response = httpClientMock.execute(httpGet("http://localhost:8080/path2"));
     Assert.assertThat(response, hasStatus(SC_NOT_FOUND));
+  }
+  
+  @Test
+  public void doReturnFormParams() throws IOException {
+    HttpClientMock httpClientMock = new HttpClientMock("http://localhost:8080");
+
+    List<NameValuePair> expected = Arrays.asList(new BasicNameValuePair("one", "1"));
+    httpClientMock.onGet("/path1").doReturnFormParams(expected);
+
+    HttpResponse response = httpClientMock.execute(httpGet("http://localhost:8080/path1"));
+    List<NameValuePair> actual = URLEncodedUtils.parse(response.getEntity());
+
+    assertThat(response, hasStatus(200));
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void doReturnFormParams_empty() throws IOException {
+    HttpClientMock httpClientMock = new HttpClientMock("http://localhost:8080");
+
+    List<NameValuePair> expected = Arrays.asList();
+    httpClientMock.onGet("/path1").doReturnFormParams(expected);
+
+    HttpResponse response = httpClientMock.execute(httpGet("http://localhost:8080/path1"));
+    List<NameValuePair> actual = URLEncodedUtils.parse(response.getEntity());
+
+    assertThat(response, hasStatus(200));
+    Assert.assertEquals(expected, actual);
   }
 
   private Action echo() {

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientVerifyTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientVerifyTest.java
@@ -241,36 +241,8 @@ public class HttpClientVerifyTest {
       new BasicNameValuePair("password", "secret!")
     )));
     httpClientMock.execute(request);
-
-    //username does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "Bob"),
-      new BasicNameValuePair("password", "secret!")
-    )));
-     httpClientMock.execute(request);
-
-    //password does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "John"),
-      new BasicNameValuePair("password", "1234")
-    )));
-    httpClientMock.execute(request);
-
-    //parameter name does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("phone", "123456789")
-    )));
-    httpClientMock.execute(request);
     
-    httpClientMock.verify().post("/login").withFormParameter("username", "John").withFormParameter("password", "secret!").called();
-    httpClientMock.verify().post("/login").withFormParameter("username", "Bob").withFormParameter("password", "secret!").called();
-    httpClientMock.verify().post("/login").withFormParameter("username", "John").withFormParameter("password", "1234").called();
-    httpClientMock.verify().post("/login").withFormParameter("phone", "123456789").called();
-    httpClientMock.verify().post("/login").withFormParameter("foo", "bar").called(0);
-    httpClientMock.verify().post("/login").withFormParameter("username", Matchers.containsString("o")).withFormParameter("password", Matchers.any(String.class)).called(3);
+    httpClientMock.verify().post("/login").withFormParameter("username", "John").withFormParameter("password", Matchers.containsString("secret")).called();
   }
   
   @Test
@@ -284,50 +256,9 @@ public class HttpClientVerifyTest {
     )));
     httpClientMock.execute(request);
     
-    //username does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "Bob"),
-      new BasicNameValuePair("password", "secret!")
-    )));
-    httpClientMock.execute(request);
-    
-    //password does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("username", "John"),
-      new BasicNameValuePair("password", "1234")
-    )));
-    httpClientMock.execute(request);
-    
-    //parameter name does not match
-    request = new HttpPost("http://localhost/login");
-    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
-      new BasicNameValuePair("phone", "123456789")
-    )));
-    httpClientMock.execute(request);
-    
     MatchersMap<String, String> parameters = new MatchersMap<>();
-    parameters.put("username", Matchers.equalTo("Bob"));
-    parameters.put("password", Matchers.equalTo("secret!"));
-    httpClientMock.verify().post("/login").withBody(parameters).called();
-    
-    parameters = new MatchersMap<>();
     parameters.put("username", Matchers.equalTo("John"));
-    parameters.put("password", Matchers.equalTo("1234"));
+    parameters.put("password", Matchers.containsString("secret"));
     httpClientMock.verify().post("/login").withBody(parameters).called();
-    
-    parameters = new MatchersMap<>();
-    parameters.put("phone", Matchers.equalTo("123456789"));
-    httpClientMock.verify().post("/login").withBody(parameters).called();
-    
-    parameters = new MatchersMap<>();
-    parameters.put("foo", Matchers.equalTo("bar"));
-    httpClientMock.verify().post("/login").withBody(parameters).called(0);
-    
-    parameters = new MatchersMap<>();
-    parameters.put("username", Matchers.containsString("o"));
-    parameters.put("password", Matchers.any(String.class));
-    httpClientMock.verify().post("/login").withBody(parameters).called(3);
   }
 }

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientVerifyTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientVerifyTest.java
@@ -5,10 +5,9 @@ import static com.github.paweladamski.httpclientmock.Requests.httpPut;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+import com.github.paweladamski.httpclientmock.matchers.MatchersMap;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -18,7 +17,6 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.message.BasicNameValuePair;
-import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -309,25 +307,25 @@ public class HttpClientVerifyTest {
     )));
     httpClientMock.execute(request);
     
-    Map<String, Matcher<String>> parameters = new HashMap<>();
+    MatchersMap<String, String> parameters = new MatchersMap<>();
     parameters.put("username", Matchers.equalTo("Bob"));
     parameters.put("password", Matchers.equalTo("secret!"));
     httpClientMock.verify().post("/login").withBody(parameters).called();
     
-    parameters = new HashMap<>();
+    parameters = new MatchersMap<>();
     parameters.put("username", Matchers.equalTo("John"));
     parameters.put("password", Matchers.equalTo("1234"));
     httpClientMock.verify().post("/login").withBody(parameters).called();
     
-    parameters = new HashMap<>();
+    parameters = new MatchersMap<>();
     parameters.put("phone", Matchers.equalTo("123456789"));
     httpClientMock.verify().post("/login").withBody(parameters).called();
     
-    parameters = new HashMap<>();
+    parameters = new MatchersMap<>();
     parameters.put("foo", Matchers.equalTo("bar"));
     httpClientMock.verify().post("/login").withBody(parameters).called(0);
     
-    parameters = new HashMap<>();
+    parameters = new MatchersMap<>();
     parameters.put("username", Matchers.containsString("o"));
     parameters.put("password", Matchers.any(String.class));
     httpClientMock.verify().post("/login").withBody(parameters).called(3);

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientVerifyTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientVerifyTest.java
@@ -246,7 +246,7 @@ public class HttpClientVerifyTest {
   }
   
   @Test
-  public void withBody_form_parameters() throws IOException {
+  public void withFormParameters() throws IOException {
     HttpClientMock httpClientMock = new HttpClientMock("http://localhost");
     
     HttpPost request = new HttpPost("http://localhost/login");
@@ -259,6 +259,6 @@ public class HttpClientVerifyTest {
     MatchersMap<String, String> parameters = new MatchersMap<>();
     parameters.put("username", Matchers.equalTo("John"));
     parameters.put("password", Matchers.containsString("secret"));
-    httpClientMock.verify().post("/login").withBody(parameters).called();
+    httpClientMock.verify().post("/login").withFormParameters(parameters).called();
   }
 }

--- a/src/test/java/com/github/paweladamski/httpclientmock/action/UrlEncodedFormEntityResponseTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/action/UrlEncodedFormEntityResponseTest.java
@@ -1,0 +1,32 @@
+package com.github.paweladamski.httpclientmock.action;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Test;
+
+/**
+ * @author Michael Angstadt
+ */
+public class UrlEncodedFormEntityResponseTest {
+  @Test
+  public void test() throws Exception {
+    List<NameValuePair> expectedPairs = Arrays.asList(new BasicNameValuePair("one", "1"), new BasicNameValuePair("two", "2"));
+    int expectedStatus = 500;
+
+    UrlEncodedFormEntityResponse action = new UrlEncodedFormEntityResponse(expectedStatus, expectedPairs, StandardCharsets.UTF_8);
+    HttpResponse response = action.getResponse(null);
+
+    List<NameValuePair> actualPairs = URLEncodedUtils.parse(response.getEntity());
+    assertEquals(expectedPairs, actualPairs);
+
+    assertEquals(expectedStatus, response.getStatusLine().getStatusCode());
+  }
+}

--- a/src/test/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormConditionTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormConditionTest.java
@@ -1,0 +1,121 @@
+package com.github.paweladamski.httpclientmock.condition;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Test;
+
+import com.github.paweladamski.httpclientmock.Request;
+
+/**
+ * @author Michael Angstadt
+ */
+public class UrlEncodedFormConditionTest {
+  @Test
+  public void valid_match() throws Exception {
+    UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+    condition.addExpectedParameter("one", equalTo("1"));
+    condition.addExpectedParameter("two", equalTo("2"));
+    
+    HttpPost request = new HttpPost();
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("one", "1"),
+      new BasicNameValuePair("two", "2")
+    )));
+    
+    Request r = new Request(null, request, null);
+    assertTrue(condition.matches(r));
+  }
+  
+  @Test
+  public void case_sensitive_names() throws Exception {
+    UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+    condition.addExpectedParameter("ONE", equalTo("1"));
+    
+    HttpPost request = new HttpPost();
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("one", "1")
+    )));
+    
+    Request r = new Request(null, request, null);
+    assertFalse(condition.matches(r));
+  }
+  
+  @Test
+  public void no_match() throws Exception {
+    UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+    condition.addExpectedParameter("one", equalTo("1"));
+    condition.addExpectedParameter("two", equalTo("2"));
+    
+    HttpPost request = new HttpPost();
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("one", "1"),
+      new BasicNameValuePair("two", "not 2")
+    )));
+    
+    Request r = new Request(null, request, null);
+    assertFalse(condition.matches(r));
+  }
+  
+  /**
+   * Parameters with the same name are not supported because there's no way of
+   * telling which Matcher to assign to which parameter.
+   */
+  @Test
+  public void duplicate_names() throws Exception {
+    UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+    condition.addExpectedParameter("one", equalTo("1"));
+    condition.addExpectedParameter("one", equalTo("3")); //overwrites the above parameter
+    
+    HttpPost request = new HttpPost();
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("one", "1"),
+      new BasicNameValuePair("one", "3")
+    )));
+    
+    Request r = new Request(null, request, null);
+    assertFalse(condition.matches(r));
+  }
+  
+  @Test
+  public void different_number_of_parameters() throws Exception {
+    UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+    condition.addExpectedParameter("one", equalTo("1"));
+    
+    HttpPost request = new HttpPost();
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("one", "1"),
+      new BasicNameValuePair("two", "2")
+    )));
+    
+    Request r = new Request(null, request, null);
+    assertFalse(condition.matches(r));
+  }
+
+  @Test
+  public void bodyless_request() {
+    //without expected params
+    {
+      UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+      HttpGet request = new HttpGet();
+      Request r = new Request(null, request, null);
+      assertTrue(condition.matches(r));
+    }
+
+    //with expected params
+    {
+      UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+      condition.addExpectedParameter("foo", equalTo("bar"));
+      HttpGet request = new HttpGet();
+      Request r = new Request(null, request, null);
+      assertFalse(condition.matches(r));
+    }
+  }
+}

--- a/src/test/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormConditionTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormConditionTest.java
@@ -1,10 +1,15 @@
 package com.github.paweladamski.httpclientmock.condition;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
@@ -12,6 +17,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
 
+import com.github.paweladamski.httpclientmock.Debugger;
 import com.github.paweladamski.httpclientmock.Request;
 
 /**
@@ -33,6 +39,11 @@ public class UrlEncodedFormConditionTest {
     
     Request r = new Request(null, request, null);
     assertTrue(condition.matches(r));
+
+    TestDebugger debugger = new TestDebugger();
+    condition.debug(r, debugger);
+    assertThat(debugger.matching, empty());
+    assertThat(debugger.notMatching, empty());
   }
   
   @Test
@@ -49,6 +60,14 @@ public class UrlEncodedFormConditionTest {
     
     Request r = new Request(null, request, null);
     assertTrue(condition.matches(r));
+    
+    TestDebugger debugger = new TestDebugger();
+    condition.debug(r, debugger);
+    assertThat(debugger.matching, contains(
+      "parameter one is \"1\"",
+      "parameter two is \"2\""
+    ));
+    assertThat(debugger.notMatching, empty());
   }
   
   @Test
@@ -63,6 +82,14 @@ public class UrlEncodedFormConditionTest {
     
     Request r = new Request(null, request, null);
     assertFalse(condition.matches(r));
+    
+    TestDebugger debugger = new TestDebugger();
+    condition.debug(r, debugger);
+    assertThat(debugger.matching, empty());
+    assertThat(debugger.notMatching, contains(
+      "parameter one was not expected to be in the request",
+      "parameter ONE is missing from the request"
+    ));
   }
   
   @Test
@@ -79,6 +106,15 @@ public class UrlEncodedFormConditionTest {
     
     Request r = new Request(null, request, null);
     assertFalse(condition.matches(r));
+    
+    TestDebugger debugger = new TestDebugger();
+    condition.debug(r, debugger);
+    assertThat(debugger.matching, contains(
+      "parameter one is \"1\""
+    ));
+    assertThat(debugger.notMatching, contains(
+      "parameter two is \"2\""
+    ));
   }
   
   /**
@@ -89,7 +125,7 @@ public class UrlEncodedFormConditionTest {
   public void duplicate_names() throws Exception {
     UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
     condition.addExpectedParameter("one", equalTo("1"));
-    condition.addExpectedParameter("one", equalTo("3")); //overwrites the above parameter
+    condition.addExpectedParameter("one", equalTo("3")); //TODO MatchersMap requires that the parameter value match BOTH conditions--so the value must equal "1" and must also equal "3", which is impossible 
     
     HttpPost request = new HttpPost();
     request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
@@ -99,6 +135,14 @@ public class UrlEncodedFormConditionTest {
     
     Request r = new Request(null, request, null);
     assertFalse(condition.matches(r));
+    
+    TestDebugger debugger = new TestDebugger();
+    condition.debug(r, debugger);
+    assertThat(debugger.matching, empty());
+    assertThat(debugger.notMatching, contains(
+      "parameter one is \"1\" and \"3\"",
+      "parameter one is \"1\" and \"3\""
+    ));
   }
   
   @Test
@@ -114,6 +158,15 @@ public class UrlEncodedFormConditionTest {
     
     Request r = new Request(null, request, null);
     assertFalse(condition.matches(r));
+    
+    TestDebugger debugger = new TestDebugger();
+    condition.debug(r, debugger);
+    assertThat(debugger.matching, contains(
+      "parameter one is \"1\""
+    ));
+    assertThat(debugger.notMatching, contains(
+      "parameter two was not expected to be in the request"
+    ));
   }
 
   @Test
@@ -124,6 +177,11 @@ public class UrlEncodedFormConditionTest {
       HttpGet request = new HttpGet();
       Request r = new Request(null, request, null);
       assertTrue(condition.matches(r));
+      
+      TestDebugger debugger = new TestDebugger();
+      condition.debug(r, debugger);
+      assertThat(debugger.matching, empty());
+      assertThat(debugger.notMatching, empty());
     }
 
     //with expected params
@@ -133,6 +191,24 @@ public class UrlEncodedFormConditionTest {
       HttpGet request = new HttpGet();
       Request r = new Request(null, request, null);
       assertFalse(condition.matches(r));
+      
+      TestDebugger debugger = new TestDebugger();
+      condition.debug(r, debugger);
+      assertThat(debugger.matching, empty());
+      assertThat(debugger.notMatching, contains(
+        "parameter foo is missing from the request"
+      ));
+    }
+  }
+  
+  private static class TestDebugger extends Debugger {
+    public final List<String> matching = new ArrayList<>();
+    public final List<String> notMatching = new ArrayList<>();
+    
+    @Override
+    public void message(boolean matches, String message) {
+      List<String> list = matches ? matching : notMatching;
+      list.add(message);
     }
   }
 }

--- a/src/test/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormConditionTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormConditionTest.java
@@ -18,6 +18,23 @@ import com.github.paweladamski.httpclientmock.Request;
  * @author Michael Angstadt
  */
 public class UrlEncodedFormConditionTest {
+  /**
+   * Condition should always match if no expected parameters were passed into it.
+   */
+  @Test
+  public void no_expected_parameters_provided() throws Exception {
+    UrlEncodedFormCondition condition = new UrlEncodedFormCondition();
+    
+    HttpPost request = new HttpPost();
+    request.setEntity(new UrlEncodedFormEntity(Arrays.asList(
+      new BasicNameValuePair("one", "1"),
+      new BasicNameValuePair("two", "2")
+    )));
+    
+    Request r = new Request(null, request, null);
+    assertTrue(condition.matches(r));
+  }
+  
   @Test
   public void valid_match() throws Exception {
     UrlEncodedFormCondition condition = new UrlEncodedFormCondition();


### PR DESCRIPTION
These kinds of form parameters are typically found in the body of POST requests when a form is submitted on a website. Don't know if this would be useful to add or not.

Examples:

```java
client.onPost("/login")
  .withFormParameter("username", "John")
  .withFormParameter("password", Matchers.any(String.class))
.doReturnStatus(200);
```

```java
Map<String, Matcher<String>> parameters = new HashMap<>();
parameters.put("username", Matchers.equalTo("John"));
parameters.put("password", Matchers.any(String.class));
client.onPost("/login")
  .withBody(parameters)
.doReturnStatus(200);
```

```java
client.onGet("/foo").doReturnFormParams(Arrays.asList(
  new BasicNameValuePair("one", "1"),
  new BasicNameValuePair("one", "2")
));
```