### PR TITLE
Reset should remove all defined rules.

### DIFF
--- a/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMock.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/HttpClientMock.java
@@ -69,6 +69,7 @@ public class HttpClientMock extends CloseableHttpClient {
    */
   public void reset() {
     this.rulesUnderConstruction.clear();
+    this.rules.clear();
     this.requests.clear();
   }
 

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockBuilderTest.java
@@ -276,7 +276,18 @@ public class HttpClientMockBuilderTest {
 
     httpClientMock.onPost("/login").doReturnStatus(200);
     httpClientMock.reset();
+    HttpResponse login = httpClientMock.execute(new HttpPost("http://localhost/login"));
 
+    assertThat(login, hasStatus(404));
+  }
+
+  @Test
+  public void after_execute_and_reset_every_call_should_result_in_status_404() throws IOException {
+    HttpClientMock httpClientMock = new HttpClientMock("http://localhost");
+
+    httpClientMock.onPost("/login").doReturnStatus(200);
+    httpClientMock.execute(new HttpPost("http://localhost/login"));
+    httpClientMock.reset();
     HttpResponse login = httpClientMock.execute(new HttpPost("http://localhost/login"));
 
     assertThat(login, hasStatus(404));


### PR DESCRIPTION
Fix for issue #27 
HttpClientMock#reset should clear a list of rules.
