### PR TITLE
Support HttpRequest with non-absolute URI

### DIFF
--- a/src/main/java/com/github/paweladamski/httpclientmock/Request.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/Request.java
@@ -1,5 +1,6 @@
 package com.github.paweladamski.httpclientmock;
 
+import java.net.URI;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.protocol.HttpContext;
@@ -30,7 +31,14 @@ public class Request {
   }
 
   public String getUri() {
-    return getHttpRequest().getRequestLine().getUri();
+    URI uri = URI.create(httpRequest.getRequestLine().getUri());
+    String urlText;
+    if (uri.isAbsolute()) {
+      urlText = uri.toString();
+    } else {
+      urlText = httpHost.toString() + uri.toString();
+    }
+    return urlText;
   }
 
 }

--- a/src/main/java/com/github/paweladamski/httpclientmock/Rule.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/Rule.java
@@ -29,13 +29,13 @@ public class Rule {
   }
 
   boolean matches(Request request) {
-    return matches(request.getHttpHost(), request.getHttpRequest(), request.getHttpContext());
+    return urlConditions.matches(request.getUri())
+        && conditions.stream()
+        .allMatch(c -> c.matches(request));
   }
 
   boolean matches(HttpHost httpHost, HttpRequest httpRequest, HttpContext httpContext) {
-    return urlConditions.matches(httpRequest.getRequestLine().getUri())
-        && conditions.stream()
-        .allMatch(c -> c.matches(httpHost, httpRequest, httpContext));
+    return matches(new Request(httpHost, httpRequest, httpContext));
   }
 
   HttpResponse nextResponse(Request request) throws IOException {

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpGet;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -32,5 +33,12 @@ public class HttpClientMockTest {
     assertThat(ok.getFirstHeader("foo").getValue(), equalTo("bar"));
   }
 
+  @Test
+  public void should_work_with_non_absolute_uri() throws IOException {
+    HttpClientMock httpClientMock = new HttpClientMock();
+    httpClientMock.onGet().doReturn("ok");
+    HttpResponse ok = httpClientMock.execute(new HttpHost("localhost"), new HttpGet("/"));
+    assertThat(ok, hasStatus(200));
+  }
 
 }


### PR DESCRIPTION
`HttpRequest.getRequestLine().getUri()` does not always have scheme and host, but can be non-absolute URI.

```
httpClientMock.execute(new HttpHost("localhost"), new HttpGet("/"));
```

Above code did not match any `Rule`s  due to `MalformedURLException` as it expects full URL.
https://github.com/PawelAdamski/HttpClientMock/blob/ea671a1556b0740cbd0971b734a5f9f4e54c3dd5/src/main/java/com/github/paweladamski/httpclientmock/UrlConditions.java#L55-L67