### PR TITLE
Add empty content-type check for request

### DIFF
--- a/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormParser.java
+++ b/src/main/java/com/github/paweladamski/httpclientmock/condition/UrlEncodedFormParser.java
@@ -36,7 +36,7 @@ public class UrlEncodedFormParser {
        * request is not "application/x-www-form-urlencoded". So, requests with
        * other kinds of data in the body will correctly be ignored here.
        */
-      if (!entity.getContentType().contains(ContentType.APPLICATION_FORM_URLENCODED.getMimeType())) {
+      if (entity.getContentType() == null || !entity.getContentType().contains(ContentType.APPLICATION_FORM_URLENCODED.getMimeType())) {
         return Collections.emptyList();
       }
       String entityContent = EntityUtils.toString(entity);

--- a/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockTest.java
+++ b/src/test/java/com/github/paweladamski/httpclientmock/HttpClientMockTest.java
@@ -6,7 +6,9 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.junit.jupiter.api.Test;
 
 public class HttpClientMockTest {
@@ -31,4 +33,17 @@ public class HttpClientMockTest {
     assertThat(ok.getFirstHeader("foo").getValue(), equalTo("bar"));
   }
 
+  @Test
+  public void should_work_when_empty_content_type() throws IOException
+  {
+    HttpClientMock httpClientMock = new HttpClientMock();
+    httpClientMock.onPost("http://localhost/Orders(Id=1)/Cancel").doReturn(200, "");
+
+    HttpPost postReq = new HttpPost("http://localhost/Orders(Id=1)/Cancel");
+    postReq.setEntity(new ByteArrayEntity(new byte[0], null));
+    HttpResponse ok = httpClientMock.execute(postReq);
+
+    assertThat(ok, hasStatus(200));
+    httpClientMock.verify().post("http://localhost/Orders(Id=1)/Cancel").called();
+  }
 }


### PR DESCRIPTION
Hi, PawelAdamski,

I encountered null-content-type in HttpEntity of HttpRequest when I upgraded to OpenFeign/feign-hc5. So I added the null check for content type. I don't know whether it is valid to have null content-type, though.
In feign-hc5, 'ApacheHttp5Client.java' has this statement: 
`requestBuilder.setEntity(new ByteArrayEntity(new byte[0], null));`

Best Regards,
William